### PR TITLE
feat: export `normalizePrivateKey`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -66,7 +66,7 @@ function ensureBytes(hex: Hex): Uint8Array {
   return u.ensureBytes('', typeof hex === 'string' ? hex0xToBytes(hex) : hex);
 }
 
-function normPrivKey(privKey: Hex): string {
+export function normPrivKey(privKey: Hex): string {
   return u.bytesToHex(ensureBytes(privKey)).padStart(64, '0');
 }
 export function getPublicKey(privKey: Hex, isCompressed = false): Uint8Array {

--- a/index.ts
+++ b/index.ts
@@ -66,14 +66,14 @@ function ensureBytes(hex: Hex): Uint8Array {
   return u.ensureBytes('', typeof hex === 'string' ? hex0xToBytes(hex) : hex);
 }
 
-export function normPrivKey(privKey: Hex): string {
+export function normalizePrivateKey(privKey: Hex): string {
   return u.bytesToHex(ensureBytes(privKey)).padStart(64, '0');
 }
 export function getPublicKey(privKey: Hex, isCompressed = false): Uint8Array {
-  return curve.getPublicKey(normPrivKey(privKey), isCompressed);
+  return curve.getPublicKey(normalizePrivateKey(privKey), isCompressed);
 }
 export function getSharedSecret(privKeyA: Hex, pubKeyB: Hex): Uint8Array {
-  return curve.getSharedSecret(normPrivKey(privKeyA), pubKeyB);
+  return curve.getSharedSecret(normalizePrivateKey(privKeyA), pubKeyB);
 }
 
 function checkSignature(signature: SignatureType) {
@@ -93,7 +93,7 @@ function checkMessage(msgHash: Hex) {
 }
 
 export function sign(msgHash: Hex, privKey: Hex, opts?: any): SignatureType {
-  const sig = curve.sign(checkMessage(msgHash), normPrivKey(privKey), opts);
+  const sig = curve.sign(checkMessage(msgHash), normalizePrivateKey(privKey), opts);
   checkSignature(sig);
   return sig;
 }

--- a/test/stark.test.js
+++ b/test/stark.test.js
@@ -228,6 +228,19 @@ describe('starknet', () => {
     );
   });
 
+  should('Private stark key normalization', () => {
+    const ethSignature =
+      '0x21fbf0696d5e0aa2ef41a2b4ffb623bcaf070461d61cf7251c74161f82fec3a43' +
+      '70854bc0a34b3ab487c1bc021cd318c734c51ae29374f2beb0e6f2dd49b4bf41c';
+    const privateKey = starknet.ethSigToPrivate(ethSignature);
+    const normalizedPrivateKey = starknet.normalizePrivateKey(privateKey);
+    deepStrictEqual(privateKey, '766f11e90cd7c7b43085b56da35c781f8c067ac0d578eabdceebc4886435bda');
+    deepStrictEqual(
+      normalizedPrivateKey,
+      '0766f11e90cd7c7b43085b56da35c781f8c067ac0d578eabdceebc4886435bda'
+    );
+  });
+
   should('Key derivation', () => {
     const layer = 'starkex';
     const application = 'starkdeployement';


### PR DESCRIPTION
Hi @paulmillr, thank you for the effort you put into this library!

Would it be possible to export `normPrivKey` on the `npm` package?
We plan to use it for account derivation logic with `grindKey` which does not always result in a padded private key.