### PR TITLE
fix: resolve TS warning after upgrade to `"typescript": "5.5.2"`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -374,7 +374,8 @@ export function poseidonHashMany(values: bigint[], fn = poseidonSmall): bigint {
     for (let j = 0; j < rate; j++) {
       const item = padded[i + j];
       if (typeof item === 'undefined') throw new Error('invalid index');
-      state[j] += item;
+      if (typeof state[j] === 'undefined') throw new Error('state[j] is undefined');
+      state[j] = state[j]! + item;
     }
     state = fn(state);
   }


### PR DESCRIPTION
CI started to fail after https://github.com/paulmillr/scure-starknet/commit/b566b4bee10545c193b19b78dd51e7e0f7045226 was merged recently

This PR fixes the CI